### PR TITLE
Revert to @wiledal's replace method to avoid RangeError

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ function processInclude(content, filePath, sourceMap) {
         replaceContent = '\n' + replaceContent;
       }
 
-      content = content.replace(matches[i], replaceContent);
+      content = content.replace(matches[i], function() { return replaceContent });
       insertedLines--; // adjust because the original line with comment was removed
     }
   }


### PR DESCRIPTION
Strangely enough, it appears as if @wiledal's method for replacing the require line might have been important. His original line was:

`content = content.replace(matches[i], function() { return replaceContent });`

I didn't understand the reason for the callback either (or maybe you did, and I'm missing something). The PR to his repo had that changed to:

`content = content.replace(matches[i], replaceContent);`

But when I used that in a fairly large project, I got this, despite that his original implementation worked fine:

```
stream.js:74
      throw er; // Unhandled stream error in pipe.
      ^

RangeError: Invalid string length
    at String.replace (native)
    at processInclude (/Users/katzgrau/Dev/esm/ESM-Web/node_modules/gulp-include/index.js:223:29)
```

This PR reverts that.

Just in case you're interested, the length of replaceContent was something like '88235701' when I printed it out, although the final file size was nowhere near that. I'm a bit baffled, but happy this has been worked out.
